### PR TITLE
Update and export event payload type

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,6 @@
 - [ ] New feature (non-breaking change that adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
-## Related issues
-
-> Fix [#1]()
-
 ## Checklists
 
 ### Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "React package for Pinwheel modal",
   "author": "roscioli",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,9 +28,10 @@ export type Error = {
   type: ErrorType
   code: string
   message: string
+  pendingRetry: boolean
 }
 
-type EventPayload =
+export type EventPayload =
   | { selectedEmployerId: string; selectedEmployerName: string }
   | { selectedPlatformId: string; selectedPlatformName: string }
   | { value: number; unit: '%' | '$' }


### PR DESCRIPTION
# Pull request details

## Description of the change

Update and export event payload type.
- Adds `pendingRetry` to the `Error` type.
- Exports `EventPayload` type

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
