### PR TITLE
Add PinwheelError and EmptyPayloadObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+## 2.3.x Releases
+
+- `2.3.x` Releases - [2.3.4](#234)
+
+---
+
+### 2.3.4
+
+#### Added
+
+- Export `EventPayload` type.
+- Export `PinwheelError` type.
+- Export `PinwheelErrorType` type.
+- Export `EmptyPayloadObject` type as `Record<string, never>`.
+
+##### Updated
+
+- `EventPayload` is no longer a union containing `{}`. It now contains `Record<string, never>` instead due to [this behavior](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-are-all-types-assignable-to-empty-interfaces).
+- Mark exported `Error` type as **@deprecated** because it collides with the built-in javascript `Error` object. Replaced with `PinwheelError`.
+- Mark exported `ErrorType` type as **@deprecated** because the new naming convention is prefixing with "`PinwheelError`". Replaced with `PinwheelErrorType`.
+- Update `onExit` type to be `(error: PinwheelError | Record<string, never>)` to be accurate with current functionality.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2000,7 +2000,7 @@
     },
     "@testing-library/jest-dom": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz",
+      "resolved": false,
       "integrity": "sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==",
       "dev": true,
       "requires": {
@@ -2017,7 +2017,7 @@
     },
     "@testing-library/react": {
       "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.5.0.tgz",
+      "resolved": false,
       "integrity": "sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==",
       "dev": true,
       "requires": {
@@ -2028,7 +2028,7 @@
     },
     "@testing-library/user-event": {
       "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-7.2.1.tgz",
+      "resolved": false,
       "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA==",
       "dev": true
     },
@@ -2122,7 +2122,7 @@
     },
     "@types/jest": {
       "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.3.tgz",
+      "resolved": false,
       "integrity": "sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==",
       "dev": true,
       "requires": {
@@ -2264,7 +2264,7 @@
     },
     "@types/node": {
       "version": "12.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
+      "resolved": false,
       "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw==",
       "dev": true
     },
@@ -13520,7 +13520,7 @@
     },
     "react-scripts": {
       "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.4.tgz",
+      "resolved": false,
       "integrity": "sha512-7J7GZyF/QvZkKAZLneiOIhHozvOMHey7hO9cdO9u68jjhGZlI8hDdOm6UyuHofn6Ajc9Uji5I6Psm/nKNuWdyw==",
       "dev": true,
       "requires": {
@@ -16242,7 +16242,7 @@
     },
     "typescript": {
       "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "resolved": false,
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "React package for Pinwheel modal",
   "author": "roscioli",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,7 +81,7 @@ interface PinwheelPublicOpenOptions {
   onLogin?: (result: { accountId: string; platformId: string }) => void
   onSuccess?: (result: LinkResult) => void
   onError?: (error: PinwheelError) => void
-  onExit?: (error?: PinwheelError | EmptyPayloadObject) => void
+  onExit?: (error: PinwheelError | EmptyPayloadObject) => void
   onEvent?: (eventName: EventName, payload: EventPayload) => void
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,9 @@ export type LinkResult = {
   }
 }
 
+/**
+ * @deprecated You should use `PinwheelErrorType` instead. `ErrorType` will be removed in version 2.4
+ */
 export type ErrorType =
   | 'clientError'
   | 'systemError'
@@ -29,11 +32,13 @@ export type ErrorType =
  * You should use `PinwheelError` instead. `Error` will be removed in version 2.4
  */
 export type Error = {
-  type: ErrorType
+  type: PinwheelErrorType
   code: string
   message: string
   pendingRetry: boolean
 }
+
+export type PinwheelErrorType = ErrorType
 
 export type PinwheelError = Error
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,12 +24,20 @@ export type ErrorType =
   | 'invalidUserInput'
   | 'invalidLinkToken'
 
+/**
+ * @deprecated The type should not be used as it clashes with the native JS `Error` object.
+ * You should use `PinwheelError` instead. `Error` will be removed in version 2.4
+ */
 export type Error = {
   type: ErrorType
   code: string
   message: string
   pendingRetry: boolean
 }
+
+export type PinwheelError = Error
+
+export type EmptyPayloadObject = {}
 
 export type EventPayload =
   | { selectedEmployerId: string; selectedEmployerName: string }
@@ -38,8 +46,8 @@ export type EventPayload =
   | LinkResult
   | { accountId: string; platformId: string }
   | { platformId: string }
-  | Error
-  | {}
+  | PinwheelError
+  | EmptyPayloadObject
   | undefined
 
 export type SemverObject = {
@@ -67,8 +75,8 @@ interface PinwheelPublicOpenOptions {
   linkToken: string
   onLogin?: (result: { accountId: string; platformId: string }) => void
   onSuccess?: (result: LinkResult) => void
-  onError?: (error: Error) => void
-  onExit?: (error?: Error) => void
+  onError?: (error: PinwheelError) => void
+  onExit?: (error?: PinwheelError | EmptyPayloadObject) => void
   onEvent?: (eventName: EventName, payload: EventPayload) => void
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,7 +42,7 @@ export type PinwheelErrorType = ErrorType
 
 export type PinwheelError = Error
 
-export type EmptyPayloadObject = {}
+export type EmptyPayloadObject = Record<string, never>
 
 export type EventPayload =
   | { selectedEmployerId: string; selectedEmployerName: string }


### PR DESCRIPTION
# Pull request details

- Export a type named PinwheelError instead of Error because it collides with the built-in javascript Error object
- Export an enum PinwheelErrorType instead of ErrorType to avoid any naming conflicts
- Update onExit type to be (error?: PinwheelError | EmptyPayloadObject) to be accurate with current functionality

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

