### PR TITLE
Allow compiling w strict TS users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.3.8",
+  "version": "2.3.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pinwheel/react-modal",
-      "version": "2.3.8",
+      "version": "2.3.10",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "description": "React package for Pinwheel modal",
   "author": "roscioli",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -136,13 +136,15 @@ const addScriptTag = (loadCb: Function, url?: string) => {
   return tag
 }
 
-const PinwheelModal = ({
-  open,
-  _srcUrl,
-  // @ts-ignore
-  _modalSessionIdOverride,
-  ...props
-}: PinwheelModalProps) => {
+const PinwheelModal = (allProps: PinwheelModalProps) => {
+  const { open, _srcUrl, ...props } = allProps
+
+  // Need to get _modalSessionIdOverride like this or else client using this module
+  // with strict typescript typing will not be able to compile this without an error.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const modalSessionIdOverride = (allProps as unknown as any)
+    ._modalSessionIdOverride
+
   const [loaded, setLoaded] = React.useState(false)
   const [showing, setShowing] = React.useState(false)
   const [tag, setTag] = React.useState<HTMLScriptElement>()
@@ -172,7 +174,7 @@ const PinwheelModal = ({
         _versionOverride: SDK_VERSION,
         _sdkOverride: 'react',
         ...props,
-        _modalSessionIdOverride
+        _modalSessionIdOverride: modalSessionIdOverride
       })
       setShowing(true)
     } else if (!open && showing) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -141,9 +141,10 @@ const PinwheelModal = (allProps: PinwheelModalProps) => {
 
   // Need to get _modalSessionIdOverride like this or else client using this module
   // with strict typescript typing will not be able to compile this without an error.
+  // Error: "node_modules/@pinwheel/react-modal/dist/index.d.ts(85,48): error TS2339: Property '_modalSessionIdOverride' does not exist on type 'PinwheelModalProps'."
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const modalSessionIdOverride = (allProps as unknown as any)
-    ._modalSessionIdOverride
+  const propsAsAny = allProps as unknown as any
+  const { _modalSessionIdOverride } = propsAsAny
 
   const [loaded, setLoaded] = React.useState(false)
   const [showing, setShowing] = React.useState(false)
@@ -174,7 +175,7 @@ const PinwheelModal = (allProps: PinwheelModalProps) => {
         _versionOverride: SDK_VERSION,
         _sdkOverride: 'react',
         ...props,
-        _modalSessionIdOverride: modalSessionIdOverride
+        _modalSessionIdOverride
       })
       setShowing(true)
     } else if (!open && showing) {


### PR DESCRIPTION
Need to get _modalSessionIdOverride like this or else client using this module with strict typescript typing will not be able to compile this without an error.

```
node_modules/@pinwheel/react-modal/dist/index.d.ts(85,48): error TS2339: Property '_modalSessionIdOverride' does not exist on type 'PinwheelModalProps'.
```