### PR TITLE
Update Portal version to include ariaHideDocumentContent and iframe title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### 2.4.2
+
+#### Added
+
+- Allow passing in the `ariaHideDocumentContent` prop, which applies `aria-hidden` to background elements in the document while the Pinwheel modal is open.
+- Add `title` attribute to the Pinwheel iframe.
+
+---
+
 ### 2.4.0
 
 #### Security

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -32,7 +32,7 @@
     },
     "..": {
       "name": "@pinwheel/react-modal",
-      "version": "2.4.0",
+      "version": "2.4.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.5",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,16 +2,24 @@ import React, { useState } from 'react'
 
 import PinwheelModal from '@pinwheel/react-modal'
 
-const token = window.location.search.split('token=')[1] ||
+const token =
+  window.location.search.split('token=')[1] ||
   'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7Im9yZ19uYW1lIjoiQXNwYXJhZ3VzIFRydXN0LCBJbmMuIiwiam9iIjoiZGlyZWN0X2RlcG9zaXRfc3dpdGNoIiwiYWNjb3VudF90eXBlIjoiY2hlY2tpbmciLCJyb3V0aW5nX251bWJlciI6IjU3NTc4MjkwOSIsImFjY291bnRfbnVtYmVyIjoiOTk5NjQxMjQ2NyIsInBsYXRmb3JtX2tleSI6bnVsbCwic2tpcF9pbnRyb19zY3JlZW4iOmZhbHNlLCJza2lwX2V4aXRfc3VydmV5IjpmYWxzZSwiYW1vdW50IjpudWxsLCJlbXBsb3llcl9pZCI6bnVsbCwiYWNjb3VudF9uYW1lIjpudWxsLCJkaXNhYmxlX2RpcmVjdF9kZXBvc2l0X3NwbGl0dGluZyI6ZmFsc2UsInNraXBfZW1wbG95ZXJfc2VhcmNoIjpudWxsLCJwbGF0Zm9ybV9pZCI6bnVsbCwicmVxdWlyZWRfam9icyI6bnVsbCwibW9kZSI6InNhbmRib3giLCJhcGlfa2V5IjoieHl6IiwidG9rZW5faWQiOiJiNjM1ZjM3OC1kZjQ0LTRlNWYtOWU1ZS04MjczYWM5ZTFhNjUifSwiaWF0IjozNjExNzc0MTkyLCJleHAiOjM2MTE3NzUwOTJ9.psETOaf7qyWGaaXvA29gTabRa-uvoGT69roY4A5z1fY'
 
 const App = () => {
   const [open, setOpen] = useState(true)
 
-  return <div>
-    <button onClick={() =>setOpen(true)}>Click me</button>
-    <PinwheelModal linkToken={token} open={open} onExit={() => setOpen(false)} />
-  </div>
+  return (
+    <div>
+      <button onClick={() => setOpen(true)}>Click me</button>
+      <PinwheelModal
+        linkToken={token}
+        open={open}
+        onExit={() => setOpen(false)}
+        ariaHideDocumentContent={true}
+      />
+    </div>
+  )
 }
 
 export default App

--- a/portal.config.json
+++ b/portal.config.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://cdn.getpinwheel.com/pinwheel-v2.3.2.js?sandbox=true",
-  "integrity": "sha512-lFhS5GWL0d1RGIq9BYKtHrcI9lyfZT9BgpvT0FTPJaSo7JuhdkJnzGtuGoinmDqdbri8/bQo/ijjvjzszeL8Ow=="
+  "url": "https://cdn.getpinwheel.com/pinwheel-v2.3.6.js?sandbox=true",
+  "integrity": "sha512-cLpxTbhICiBfvoXohrUyq9bsgFGDmBY4UsBjfc4DOJT20B2jl6yzeTUeH2bBRWjjTb/yMpzdQ91YgyRzwH/pyg=="
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -128,6 +128,7 @@ interface PinwheelPublicOpenOptions {
    * @experimental - Adjust modal height, width, and placement on screen
    */
   modalStyling?: ModalStylingParams
+  ariaHideDocumentContent?: boolean
 }
 
 interface PinwheelPrivateOpenOptions {


### PR DESCRIPTION
# Pull request details

## Description of the change

- Updates Portal version to 2.3.6, which includes support for the `ariaHideDocumentContent` prop and sets the `title` attribute on the iframe.
- Updates `PinwheelModalProps` to include `ariaHideDocumentContent`, and enables this option on the example app. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
