### PR TITLE
Update Portal version to include postMessage security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### 2.4.4
+
+#### Security
+
+- Pass parent window origin to the Link iframe, so that cross-origin messages are verified and always have a target origin set.
+
+---
+
 ### 2.4.3
 
 #### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pinwheel/react-modal",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "React package for Pinwheel modal",
   "author": "roscioli",
   "license": "MIT",

--- a/portal.config.json
+++ b/portal.config.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://cdn.getpinwheel.com/pinwheel-v2.3.6.js?sandbox=true",
-  "integrity": "sha512-cLpxTbhICiBfvoXohrUyq9bsgFGDmBY4UsBjfc4DOJT20B2jl6yzeTUeH2bBRWjjTb/yMpzdQ91YgyRzwH/pyg=="
+  "url": "https://cdn.getpinwheel.com/pinwheel-v2.3.10.js?sandbox=true",
+  "integrity": "sha512-nSH4irJRnRLjvq0Klk9tAL2B3DSEIyvN6JXEPrt7uV1AvJtf6bp2ZdymV6e9M23iLvBGXCYJ1gv+1SQ+IxkmdQ=="
 }


### PR DESCRIPTION
# Pull request details

## Description of the change

Updates the Portal version to 2.3.10. This passes the parent window origin to the Link iframe, so that cross-origin messages are verified and always have a target origin set.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
