### PR TITLE
Update Portal version to include the clipboard-write iframe permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### 2.4.5
+
+#### Added
+
+- Add the `clipboard-write` permission to the Pinwheel iframe.
+
+---
+
 ### 2.4.4
 
 #### Security

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -32,7 +32,7 @@
     },
     "..": {
       "name": "@pinwheel/react-modal",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pinwheel/react-modal",
-      "version": "2.4.4",
+      "version": "2.4.5",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "React package for Pinwheel modal",
   "author": "roscioli",
   "license": "MIT",

--- a/portal.config.json
+++ b/portal.config.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://cdn.getpinwheel.com/pinwheel-v2.3.10.js?sandbox=true",
-  "integrity": "sha512-nSH4irJRnRLjvq0Klk9tAL2B3DSEIyvN6JXEPrt7uV1AvJtf6bp2ZdymV6e9M23iLvBGXCYJ1gv+1SQ+IxkmdQ=="
+  "url": "https://cdn.getpinwheel.com/pinwheel-v2.3.11.js?sandbox=true",
+  "integrity": "sha512-NYgZ1R22gaRTXslvZwwktxkMiQ9WCz+RSCdxiwZdhYhdW7nD1kv0tR99/XXJAheSDgVUAQO1+WWTyIkwfWykMA=="
 }


### PR DESCRIPTION
# Pull request details

## Description of the change

Updates the Portal version to 2.3.11. This adds the `clipboard-write` permission to the Pinwheel iframe, enabling programmatic clipboard copying in the Link modal.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
