### PR TITLE
Prepares v4 (Bill Manager client events)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to this project will be documented in this file.
 
+## 4.0.x Releases
+
+- `4.0.x` Releases - [4.0.0](#400)
+
+### 4.0.0
+
+#### Removed
+
+- Removed deprecated type aliases for client events `InputAllocation` and `ScreenTransition`. Use their base types `InputAllocationEventPayload` and `ScreenTransitionEventPayload` instead.
+
+#### Added
+
+- Adds new client events for Bill Manager product:
+  - `bill_cancel_success`, `bill_cancel_failure` (`BillSwitchEventPayload`).
+  - `calendar_sync` (`CalendarSyncEventPayload`).
+  - `recurring_charge_added`, `recurring_charge_edited`, `recurring_charge_marked_inactive`, `recurring_charge_removed` (`RecurringChargeEventPayload`).
+- Adds new client events for Bill Switch product:
+  - `bill_switch_platforms_added`, `bill_switch_platforms_removed` (`BillSwitchPlatformsAddedEventPayload`).
+- Adds bill switch failure event (for both Bill Switch and Bill Manager products): `bill_switch_failure` (`BillSwitchEventPayload`).
+- Adds new global client events:
+  - `customer_terms_accepted` for customer workspaces with special terms in Bill Suite products, this event fires when the user accepts these special customer terms. Has an empty object payload.
+  - `user_activated` fires when a user clicks 'Continue' to start their experience with Pinwheel. Includes a payload with `solutionName` set to the name of the solution this Link session was created for, eg "Bill Switch", "Bill Manager", etc.
+
+#### Modified
+
+- Standardized payload types for existing bill switch events:
+  - `bill_switch_success`, `bill_removed` (`BillSwitchEventPayload`).
+  - Renamed `ExternalAccountConnectedPayload` to `ExternalAccountConnectedEventPayload` to maintain consistency with other event payload type names.
+
+## 3.5.x Releases
+
+- `3.5.x` Releases - [3.5.0](#350) | [3.5.1](#351)
+
+### 3.5.0
+
+#### Added
+
+- Adds 'useSecureOrigin' prop to tell the SDK to use Pinwheel's CSP for the Pinwheel web app.
+
+### 3.5.1
+
+#### Updated
+
+- Updates 'useSecureOrigin' to apply directly to Portal URL.
+
 ## 3.4.x Releases
 
 - `3.4.x` Releases - [3.4.0](#340)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## 4.0.x Releases
+
+- `4.0.x` Releases - [4.0.0](#400)
+
+### 4.0.0
+
+#### Removed
+
+- Removed deprecated type aliases for client events `InputAllocation` and `ScreenTransition`. Use their base types `InputAllocationEventPayload` and `ScreenTransitionEventPayload` instead.
+
+#### Added
+
+- Adds new client events for Bill Manager product:
+  - `bill_cancel_success`, `bill_cancel_failure` (`BillSwitchEventPayload`).
+  - `calendar_sync` (`CalendarSyncEventPayload`).
+  - `recurring_charge_added`, `recurring_charge_edited`, `recurring_charge_marked_inactive`, `recurring_charge_removed` (`RecurringChargeEventPayload`).
+- Adds new client events for Bill Switch product:
+  - `bill_switch_platforms_added`, `bill_switch_platforms_removed` (`BillSwitchPlatformsAddedEventPayload`).
+- Adds bill switch failure event (for both Bill Switch and Bill Manager products): `bill_switch_failure` (`BillSwitchEventPayload`).
+
+#### Modified
+
+- Standardized payload types for existing bill switch events:
+  - `bill_switch_success`, `bill_removed` (`BillSwitchEventPayload`).
+  - Renamed `ExternalAccountConnectedPayload` to `ExternalAccountConnectedEventPayload` to maintain consistency with other event payload type names.
+
+## 3.5.x Releases
+
+- `3.5.x` Releases - [3.5.0](#350) | [3.5.1](#351)
+
+### 3.5.0
+
+#### Added
+
+- Adds 'useSecureOrigin' prop to tell the SDK to use Pinwheel's CSP for the Pinwheel web app.
+
+### 3.5.1
+
+#### Updated
+
+- Updates 'useSecureOrigin' to apply directly to Portal URL.
+
 ## 3.4.x Releases
 
 - `3.4.x` Releases - [3.4.0](#340)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "3.5.1",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pinwheel/react-modal",
-      "version": "3.5.1",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "3.5.1",
+  "version": "4.0.0",
   "description": "React package for Pinwheel modal",
   "author": "@pinwheel",
   "license": "MIT",

--- a/src/client-events/registry/v2.3.ts
+++ b/src/client-events/registry/v2.3.ts
@@ -16,6 +16,12 @@ export type LinkApiJob = 'login' | 'direct_deposit_switch' | 'card_switch'
 
 export type OpenEventPayload = {}
 
+export type CustomerTermsAcceptedEventPayload = {}
+
+export type UserActivatedEventPayload = {
+  solutionName: string
+}
+
 export type SelectEmployerEventPayload = {
   selectedEmployerId: string
   selectedEmployerName: string
@@ -60,11 +66,6 @@ export type InputAllocationEventPayload =
   | InputAllocationAmount
   | InputAllocationPercentage
 
-/**
- * @deprecated - Use `InputAllocationEventPayload` instead.
- */
-export type InputAllocation = InputAllocationEventPayload
-
 export type CardSwitchBeginEventPayload = {}
 
 export type DocUploadsBeginEventPayload = {
@@ -91,24 +92,33 @@ export type ScreenTransitionEventPayload = {
   selectedPlatformName?: string
 }
 
-export type BillSwitchPayload = {
+type BillMetadata = {
   platformId: string
   platformName: string
-  isIntegratedSwitch: boolean
   frequency: string
   nextPaymentDate: string
   amountCents: number
 }
 
-export type ExternalAccountConnectedPayload = {
+type BillActionBase = {
+  isIntegratedSwitch: boolean
+  accountId?: string
+}
+
+export type BillSwitchEventPayload = BillActionBase & BillMetadata
+
+export type RecurringChargeEventPayload = BillMetadata
+
+export type ExternalAccountConnectedEventPayload = {
   institutionName: string
   accountName: string
 }
 
-/**
- * @deprecated - Use `ScreenTransitionEventPayload` instead.
- */
-export type ScreenTransition = ScreenTransitionEventPayload
+export type BillSwitchPlatformsAddedEventPayload = {
+  platforms: { id: string; name: string }[]
+}
+
+export type CalendarSyncEventPayload = { calendarType: 'google' | 'outlook' }
 
 export type ExitEventPayload = Record<string, never>
 
@@ -152,10 +162,22 @@ type EventPayloadAdditions = {
   exit: ErrorEventPayload | ExitEventPayload
   success: SuccessEventPayload
   error: ErrorEventPayload
-  bill_switch_success: BillSwitchPayload
-  bill_removed: BillSwitchPayload
-  external_account_connected: ExternalAccountConnectedPayload
+  bill_switch_success: BillSwitchEventPayload
+  bill_switch_failure: BillSwitchEventPayload
+  bill_removed: BillSwitchEventPayload
+  external_account_connected: ExternalAccountConnectedEventPayload
   merchant_login_success: LoginEventPayload
+  bill_switch_platforms_added: BillSwitchPlatformsAddedEventPayload
+  bill_switch_platforms_removed: BillSwitchPlatformsAddedEventPayload
+  bill_cancel_success: BillSwitchEventPayload
+  bill_cancel_failure: BillSwitchEventPayload
+  calendar_sync: CalendarSyncEventPayload
+  recurring_charge_removed: RecurringChargeEventPayload
+  recurring_charge_marked_inactive: RecurringChargeEventPayload
+  recurring_charge_edited: RecurringChargeEventPayload
+  recurring_charge_added: RecurringChargeEventPayload
+  customer_terms_accepted: CustomerTermsAcceptedEventPayload
+  user_activated: UserActivatedEventPayload
 }
 
 type EventPayloadModifications = {}

--- a/src/client-events/registry/v2.3.ts
+++ b/src/client-events/registry/v2.3.ts
@@ -60,11 +60,6 @@ export type InputAllocationEventPayload =
   | InputAllocationAmount
   | InputAllocationPercentage
 
-/**
- * @deprecated - Use `InputAllocationEventPayload` instead.
- */
-export type InputAllocation = InputAllocationEventPayload
-
 export type CardSwitchBeginEventPayload = {}
 
 export type DocUploadsBeginEventPayload = {
@@ -91,24 +86,33 @@ export type ScreenTransitionEventPayload = {
   selectedPlatformName?: string
 }
 
-export type BillSwitchPayload = {
+type BillMetadata = {
   platformId: string
   platformName: string
-  isIntegratedSwitch: boolean
   frequency: string
   nextPaymentDate: string
   amountCents: number
 }
 
-export type ExternalAccountConnectedPayload = {
+type BillActionBase = {
+  isIntegratedSwitch: boolean
+  accountId?: string
+}
+
+export type BillSwitchEventPayload = BillActionBase & BillMetadata
+
+export type RecurringChargeEventPayload = BillMetadata
+
+export type ExternalAccountConnectedEventPayload = {
   institutionName: string
   accountName: string
 }
 
-/**
- * @deprecated - Use `ScreenTransitionEventPayload` instead.
- */
-export type ScreenTransition = ScreenTransitionEventPayload
+export type BillSwitchPlatformsAddedEventPayload = {
+  platforms: { id: string; name: string }[]
+}
+
+export type CalendarSyncEventPayload = { calendarType: 'google' | 'outlook' }
 
 export type ExitEventPayload = Record<string, never>
 
@@ -152,10 +156,20 @@ type EventPayloadAdditions = {
   exit: ErrorEventPayload | ExitEventPayload
   success: SuccessEventPayload
   error: ErrorEventPayload
-  bill_switch_success: BillSwitchPayload
-  bill_removed: BillSwitchPayload
-  external_account_connected: ExternalAccountConnectedPayload
+  bill_switch_success: BillSwitchEventPayload
+  bill_switch_failure: BillSwitchEventPayload
+  bill_removed: BillSwitchEventPayload
+  external_account_connected: ExternalAccountConnectedEventPayload
   merchant_login_success: LoginEventPayload
+  bill_switch_platforms_added: BillSwitchPlatformsAddedEventPayload
+  bill_switch_platforms_removed: BillSwitchPlatformsAddedEventPayload
+  bill_cancel_success: BillSwitchEventPayload
+  bill_cancel_failure: BillSwitchEventPayload
+  calendar_sync: CalendarSyncEventPayload
+  recurring_charge_removed: RecurringChargeEventPayload
+  recurring_charge_marked_inactive: RecurringChargeEventPayload
+  recurring_charge_edited: RecurringChargeEventPayload
+  recurring_charge_added: RecurringChargeEventPayload
 }
 
 type EventPayloadModifications = {}

--- a/src/client-events/registry/v3.ts
+++ b/src/client-events/registry/v3.ts
@@ -21,11 +21,6 @@ export type InputAllocationEventPayload =
   | { action: null; allocation: null }
   | InputAllocationEventPayload2_3
 
-/**
- * @deprecated - Use `InputAllocationEventPayload` instead.
- */
-export type InputAllocation = InputAllocationEventPayload
-
 type EventPayloadAdditions = {}
 
 type EventPayloadModifications = {


### PR DESCRIPTION
# Pull request details

## Description of the change

Bumped package version from 3.5.1 to 4.0.0. Removed deprecated type aliases `InputAllocation` and `ScreenTransition` from client event registry. Added new event payload types for bill management operations including `BillSwitchEventPayload`, `RecurringChargeEventPayload`, `BillSwitchPlatformsAddedEventPayload`, and `CalendarSyncEventPayload`. Introduced new event types for bill switch failures, platform management, bill cancellation, calendar sync, and recurring charge operations. Renamed existing payload types to follow consistent naming convention with "EventPayload" suffix.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)