### PR TITLE
React Modal v4.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## 4.0.x Releases
 
-- `4.0.x` Releases - [4.0.0](#400)
+- `4.0.x` Releases - [4.0.1](#401)
 
-### 4.0.0
+### 4.0.1
 
 #### Removed
 
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 - Adds new client events for Bill Manager product:
   - `bill_cancel_success`, `bill_cancel_failure` (`BillSwitchEventPayload`).
   - `calendar_sync` (`CalendarSyncEventPayload`).
-  - `recurring_charge_added`, `recurring_charge_edited`, `recurring_charge_marked_inactive`, `recurring_charge_removed` (`RecurringChargeEventPayload`).
+  - `bill_added`, `bill_edited`, `bill_marked_inactive` (`BillEventPayload`).
 - Adds new client events for Bill Switch product:
   - `bill_switch_platforms_added`, `bill_switch_platforms_removed` (`BillSwitchPlatformsAddedEventPayload`).
 - Adds bill switch failure event (for both Bill Switch and Bill Manager products): `bill_switch_failure` (`BillSwitchEventPayload`).
@@ -28,7 +28,8 @@ All notable changes to this project will be documented in this file.
 #### Modified
 
 - Standardized payload types for existing bill switch events:
-  - `bill_switch_success`, `bill_removed` (`BillSwitchEventPayload`).
+  - `bill_switch_success` now uses `BillSwitchEventPayload` in v4 which removes the `isGuidedSwitch` payload key.
+  - `bill_removed` now uses `BillEventPayload` in v4 which removes the `isGuidedSwitch` and `isIntegratedSwitch` payload keys and keeps it inline with the other bill events.
   - Renamed `ExternalAccountConnectedPayload` to `ExternalAccountConnectedEventPayload` to maintain consistency with other event payload type names.
 
 ## 3.5.x Releases

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pinwheel/react-modal",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinwheel/react-modal",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "React package for Pinwheel modal",
   "author": "@pinwheel",
   "license": "MIT",

--- a/portal.config.json
+++ b/portal.config.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://cdn.getpinwheel.com/pinwheel-v3.2.1.js",
-  "integrity": "sha512-8nhGWIhOylUp6xOo8uya8DmHTs69mviBEzqFg9v08nPvOERw+0wVGxOWBvWAwrBsCSm76UqIFY7PoggwSBhzsA=="
+  "url": "https://cdn.getpinwheel.com/pinwheel-v4.0.0.js",
+  "integrity": "sha512-0vq4BvJg+ZW+XdaVvZf2BTNgnDLGHKqLDWbueSqJX8JoDCC9D63W5nK7Kp8f9bkY9EvQ6Gfic3zZZueAK2xHtg=="
 }

--- a/src/client-events/client.ts
+++ b/src/client-events/client.ts
@@ -1,14 +1,13 @@
 import type {
-  LoginEventPayload,
-  SuccessEventPayload,
-  EventHandler,
   ErrorEventPayload,
-  LoginAttemptEventPayload
-} from './registry/v3'
+  EventHandler,
+  LoginAttemptEventPayload,
+  LoginEventPayload,
+  SuccessEventPayload
+} from './registry/v4'
 
 export type LinkOptions = {
   linkToken: string
-  useDarkMode?: boolean
   onLogin?: (payload: LoginEventPayload) => void
   onLoginAttempt?: (payload: LoginAttemptEventPayload) => void
   onSuccess?: (payload: SuccessEventPayload) => void

--- a/src/client-events/registry/v2.3.ts
+++ b/src/client-events/registry/v2.3.ts
@@ -107,7 +107,12 @@ type BillActionBase = {
 
 export type BillSwitchEventPayload = BillActionBase & BillMetadata
 
-export type RecurringChargeEventPayload = BillMetadata
+export type BillSwitchPayload = BillActionBase &
+  BillMetadata & {
+    isGuidedSwitch: boolean
+  }
+
+export type BillEventPayload = BillMetadata
 
 export type ExternalAccountConnectedEventPayload = {
   institutionName: string
@@ -162,9 +167,11 @@ type EventPayloadAdditions = {
   exit: ErrorEventPayload | ExitEventPayload
   success: SuccessEventPayload
   error: ErrorEventPayload
-  bill_switch_success: BillSwitchEventPayload
+  // @deprecated - v4 event interface uses BillSwitchEventPayload
+  bill_switch_success: BillSwitchPayload
   bill_switch_failure: BillSwitchEventPayload
-  bill_removed: BillSwitchEventPayload
+  // @deprecated - v4 event interface uses BillEventPayload
+  bill_removed: BillSwitchPayload
   external_account_connected: ExternalAccountConnectedEventPayload
   merchant_login_success: LoginEventPayload
   bill_switch_platforms_added: BillSwitchPlatformsAddedEventPayload
@@ -172,10 +179,9 @@ type EventPayloadAdditions = {
   bill_cancel_success: BillSwitchEventPayload
   bill_cancel_failure: BillSwitchEventPayload
   calendar_sync: CalendarSyncEventPayload
-  recurring_charge_removed: RecurringChargeEventPayload
-  recurring_charge_marked_inactive: RecurringChargeEventPayload
-  recurring_charge_edited: RecurringChargeEventPayload
-  recurring_charge_added: RecurringChargeEventPayload
+  bill_marked_inactive: BillEventPayload
+  bill_edited: BillEventPayload
+  bill_added: BillEventPayload
   customer_terms_accepted: CustomerTermsAcceptedEventPayload
   user_activated: UserActivatedEventPayload
 }

--- a/src/client-events/registry/v4.ts
+++ b/src/client-events/registry/v4.ts
@@ -1,0 +1,34 @@
+/* eslint-disable camelcase */
+/* eslint-disable @typescript-eslint/ban-types */
+import type { AdditionsType, ModificationsType, RemovalsType } from '../utils'
+import type {
+  BillEventPayload,
+  BillSwitchEventPayload,
+  EventPayloadMap as EventPayloadMapV3
+} from './v3'
+
+/*
+ * Export all the types from V3 and we override whatever changes
+ */
+export * from './v3'
+
+type EventPayloadAdditions = {}
+
+type EventPayloadModifications = {
+  bill_removed: BillEventPayload
+  bill_switch_success: BillSwitchEventPayload
+}
+
+type EventPayloadRemovals = []
+
+export type EventPayloadMap = Omit<
+  EventPayloadMapV3 &
+    AdditionsType<EventPayloadAdditions> &
+    ModificationsType<EventPayloadModifications>,
+  keyof RemovalsType<EventPayloadRemovals>
+>
+
+export type EventHandler = <T extends keyof EventPayloadMap>(
+  eventName: T,
+  payload: EventPayloadMap[T]
+) => void

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,6 +49,7 @@ type PinwheelPublicOpenOptions = {
   modalStyling?: ModalStylingParams
   overlayStyling?: OverlayStylingParams
   ariaHideDocumentContent?: boolean
+  useDarkMode?: boolean
   useSecureOrigin?: boolean
 } & LinkOptions
 


### PR DESCRIPTION
# Pull request details

## Description of the change

Replaces v4.0.0 which had mis-named events and payload types.

> Bumps the package version to `4.0.1` and refines the Bill Manager event payload types introduced in `4.0.0`.
>
> - Implements `bill_added`, `bill_edited`, and `bill_marked_inactive`, using the new `BillEventPayload` type.
> - Updates `bill_removed` to use `BillEventPayload` in v4, removing the `isGuidedSwitch` and `isIntegratedSwitch` payload keys to keep it consistent with other bill events.
> - Updates `bill_switch_success` to use `BillSwitchEventPayload` in v4, removing the `isGuidedSwitch` payload key.
> - Introduces a new `v4` event registry that extends `v3`, applying the above modifications via the existing `AdditionsType`/`ModificationsType`/`RemovalsType` utility pattern.
> - Moves `useDarkMode` from `LinkOptions` to `PinwheelPublicOpenOptions`.
> - Updates `client.ts` to import types from the `v4` registry instead of `v3`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)